### PR TITLE
fix(process): use dbus-send on linux to trigger screensave and/or lock the screen

### DIFF
--- a/process.js
+++ b/process.js
@@ -31,10 +31,10 @@ let commands = {
   },
   linux: {
     screensaver () {
-      return 'gnome-screensaver-command -a'
+      return 'dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.SetActive boolean:true'
     },
     lock () {
-      return 'gnome-screensaver-command -l'
+      return 'dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock'
     },
     shutdown () {
       return 'systemctl poweroff'


### PR DESCRIPTION
A way to change the lock screen/screensaver state for newer systems.